### PR TITLE
Fix regex

### DIFF
--- a/arxivbot.py
+++ b/arxivbot.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from maubot import Plugin
 from maubot.handlers import command
 
+regex_expr = r'(https?://arxiv\.org/abs/(?:[a-z\-]*/)?[0-9]+\.?[0-9]+)'
 
 class ArXivBot(Plugin):
 
@@ -49,7 +50,7 @@ class ArXivBot(Plugin):
         authors = ", ".join(authors)
         return {"title": title, "authors": authors, "date": date, "abstract": abstract, "pdf": pdf}
 
-    @command.passive(r'(https?://arxiv\.org/abs/(?:quant-ph/)?[0-9\.]+)', multiple=True, multiline=True)
+    @command.passive(regex_expr, multiple=True, multiline=True)
     async def arxiv(self, evt, matches):
         for _, match in matches:
             d = await self._parse_arxiv(match)

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.2.1
 id: com.iyanmv.arxivbot
-version: 0.0.5
+version: 0.0.6
 license: GPL-3.0-only
 modules:
   - arxivbot

--- a/test_regex.py
+++ b/test_regex.py
@@ -1,0 +1,66 @@
+import unittest
+import re
+
+with open('arxivbot.py', 'r') as f:
+    mod = f.readlines()
+    regex_expr = mod[6].split("'")[1]
+
+
+class TestRegexExpressionOneMatch(unittest.TestCase):
+    def setUp(self):
+        self.r = re.compile(regex_expr)
+        self.match = "https://arxiv.org/abs/1109.3195"
+    def test_single_url(self):
+        text = "https://arxiv.org/abs/1109.3195"
+        self.assertEqual(self.r.search(text).group(), self.match)
+    def test_single_url_period(self):
+        text = "https://arxiv.org/abs/1109.3195."
+        self.assertEqual(self.r.search(text).group(), self.match)
+    def test_single_url_inside_text(self):
+        text = "Hey! Check this paper: https://arxiv.org/abs/1109.3195. What do you think?"
+        self.assertEqual(self.r.search(text).group(), self.match)
+    def test_single_url_multiple_lines(self):
+        text = "\nhttps://arxiv.org/abs/1109.3195\n\n"
+        self.assertEqual(self.r.search(text).group(), self.match)
+    def test_single_url_parenthesis(self):
+        text = "This paper (https://arxiv.org/abs/1109.3195) looks interesting."
+        self.assertEqual(self.r.search(text).group(), self.match)
+
+class TestRegexExpressionOldURLs(unittest.TestCase):
+    def setUp(self):
+        self.r = re.compile(regex_expr)
+    def test_quant_ph(self):
+        text = "https://arxiv.org/abs/quant-ph/0512258"
+        self.assertEqual(self.r.search(text).group(), text)
+    def test_hep_ex(self):
+        text = "https://arxiv.org/abs/hep-ex/0102001"
+        self.assertEqual(self.r.search(text).group(), text)
+    def test_math_ph(self):
+        text = "https://arxiv.org/abs/math-ph/9810001"
+        self.assertEqual(self.r.search(text).group(), text)
+    def test_cs(self):
+        text = "https://arxiv.org/abs/cs/9902001"
+        self.assertEqual(self.r.search(text).group(), text)
+
+class TestRegexExpressionMultipleMatches(unittest.TestCase):
+    def setUp(self):
+        self.r = re.compile(regex_expr)
+        self.matches = ["https://arxiv.org/abs/quant-ph/0512258", "https://arxiv.org/abs/quant-ph/9806051",
+                        "https://arxiv.org/abs/0810.4372", "https://arxiv.org/abs/quant-ph/9810080"]
+    def test_multiple_matches_simple(self):
+        text = "https://arxiv.org/abs/quant-ph/0512258 https://arxiv.org/abs/quant-ph/9806051 "\
+             + "https://arxiv.org/abs/0810.4372 https://arxiv.org/abs/quant-ph/9810080"
+        self.assertEqual(self.r.findall(text), self.matches)
+    def test_multiple_matches_no_spaces(self):
+        text = "https://arxiv.org/abs/quant-ph/0512258https://arxiv.org/abs/quant-ph/9806051"\
+             + "https://arxiv.org/abs/0810.4372https://arxiv.org/abs/quant-ph/9810080"
+        self.assertEqual(self.r.findall(text), self.matches)
+    def test_multiple_matches_paragraph(self):
+        text = """https://arxiv.org/abs/quant-ph/0512258. Also, did you read this (https://arxiv.org/abs/quant-ph/9806051)?
+        And what about this other one: https://arxiv.org/abs/0810.4372
+        https://arxiv.org/abs/quant-ph/9810080"""
+        self.assertEqual(self.r.findall(text), self.matches)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes #5 and makes regex expression compatible with any old subject class (papers from before 2017) instead of just quant-ph.